### PR TITLE
Introduce H2 in-memory database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
       <version>1.3.10</version>
     </dependency>
     <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.2.220</version>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>4.0.1</version>

--- a/src/com/alpacatours/dao/BookingDAO.java
+++ b/src/com/alpacatours/dao/BookingDAO.java
@@ -1,19 +1,52 @@
 package com.alpacatours.dao;
 
 import com.alpacatours.model.Booking;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class BookingDAO {
-    private static final List<Booking> bookings = new ArrayList<>();
-    private static int idCounter = 1;
-
     public void save(Booking booking) {
-        booking.setId(idCounter++);
-        bookings.add(booking);
+        Connection conn = Database.getConnection();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO bookings(userId, tourId, numPeople, bookingDate) VALUES (?,?,?,?)",
+                Statement.RETURN_GENERATED_KEYS)) {
+            ps.setInt(1, booking.getUserId());
+            ps.setInt(2, booking.getTourId());
+            ps.setInt(3, booking.getNumPeople());
+            ps.setDate(4, booking.getBookingDate());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    booking.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 
     public List<Booking> findAll() {
-        return bookings;
+        List<Booking> list = new ArrayList<>();
+        Connection conn = Database.getConnection();
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT id,userId,tourId,numPeople,bookingDate FROM bookings")) {
+            while (rs.next()) {
+                Booking b = new Booking();
+                b.setId(rs.getInt("id"));
+                b.setUserId(rs.getInt("userId"));
+                b.setTourId(rs.getInt("tourId"));
+                b.setNumPeople(rs.getInt("numPeople"));
+                b.setBookingDate(rs.getDate("bookingDate"));
+                list.add(b);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
     }
 }

--- a/src/com/alpacatours/dao/Database.java
+++ b/src/com/alpacatours/dao/Database.java
@@ -1,0 +1,57 @@
+package com.alpacatours.dao;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class Database {
+    private static Connection connection;
+
+    static {
+        try {
+            Class.forName("org.h2.Driver");
+            connection = DriverManager.getConnection("jdbc:h2:mem:alpaca;DB_CLOSE_DELAY=-1");
+            init();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void init() throws SQLException {
+        Statement stmt = connection.createStatement();
+        stmt.execute("CREATE TABLE IF NOT EXISTS users(" +
+                "id INT AUTO_INCREMENT PRIMARY KEY," +
+                "username VARCHAR(255)," +
+                "password VARCHAR(255)," +
+                "role VARCHAR(255))");
+        stmt.execute("CREATE TABLE IF NOT EXISTS tours(" +
+                "id INT AUTO_INCREMENT PRIMARY KEY," +
+                "title VARCHAR(255)," +
+                "location VARCHAR(255)," +
+                "price DOUBLE," +
+                "description VARCHAR(255)," +
+                "capacity INT)");
+        stmt.execute("CREATE TABLE IF NOT EXISTS bookings(" +
+                "id INT AUTO_INCREMENT PRIMARY KEY," +
+                "userId INT," +
+                "tourId INT," +
+                "numPeople INT," +
+                "bookingDate DATE)");
+        stmt.close();
+    }
+
+    public static Connection getConnection() {
+        return connection;
+    }
+
+    public static void reset() {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.executeUpdate("DELETE FROM bookings");
+            stmt.executeUpdate("DELETE FROM tours");
+            stmt.executeUpdate("DELETE FROM users");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/com/alpacatours/dao/TourDAO.java
+++ b/src/com/alpacatours/dao/TourDAO.java
@@ -1,27 +1,76 @@
 package com.alpacatours.dao;
 
 import com.alpacatours.model.Tour;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class TourDAO {
-    private static final List<Tour> tours = new ArrayList<>();
-    private static int idCounter = 1;
-
     public void save(Tour tour) {
-        tour.setId(idCounter++);
-        tours.add(tour);
+        Connection conn = Database.getConnection();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO tours(title, location, price, description, capacity) VALUES (?,?,?,?,?)",
+                Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, tour.getTitle());
+            ps.setString(2, tour.getLocation());
+            ps.setDouble(3, tour.getPrice());
+            ps.setString(4, tour.getDescription());
+            ps.setInt(5, tour.getCapacity());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    tour.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 
     public List<Tour> findAll() {
-        return tours;
+        List<Tour> list = new ArrayList<>();
+        Connection conn = Database.getConnection();
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT id,title,location,price,description,capacity FROM tours")) {
+            while (rs.next()) {
+                Tour t = new Tour();
+                t.setId(rs.getInt("id"));
+                t.setTitle(rs.getString("title"));
+                t.setLocation(rs.getString("location"));
+                t.setPrice(rs.getDouble("price"));
+                t.setDescription(rs.getString("description"));
+                t.setCapacity(rs.getInt("capacity"));
+                list.add(t);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
     }
 
     public Tour findById(int id) {
-        for (Tour t : tours) {
-            if (t.getId() == id) {
-                return t;
+        Connection conn = Database.getConnection();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT id,title,location,price,description,capacity FROM tours WHERE id=?")) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Tour t = new Tour();
+                    t.setId(rs.getInt("id"));
+                    t.setTitle(rs.getString("title"));
+                    t.setLocation(rs.getString("location"));
+                    t.setPrice(rs.getDouble("price"));
+                    t.setDescription(rs.getString("description"));
+                    t.setCapacity(rs.getInt("capacity"));
+                    return t;
+                }
             }
+        } catch (SQLException e) {
+            e.printStackTrace();
         }
         return null;
     }

--- a/src/com/alpacatours/dao/UserDAO.java
+++ b/src/com/alpacatours/dao/UserDAO.java
@@ -1,23 +1,49 @@
 package com.alpacatours.dao;
 
 import com.alpacatours.model.User;
-import java.util.ArrayList;
-import java.util.List;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.SQLException;
 
 public class UserDAO {
-    private static final List<User> users = new ArrayList<>();
-    private static int idCounter = 1;
-
     public void save(User user) {
-        user.setId(idCounter++);
-        users.add(user);
+        Connection conn = Database.getConnection();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO users(username, password, role) VALUES (?,?,?)",
+                Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, user.getUsername());
+            ps.setString(2, user.getPassword());
+            ps.setString(3, user.getRole());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    user.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 
     public User findByUsername(String username) {
-        for (User u : users) {
-            if (u.getUsername().equals(username)) {
-                return u;
+        Connection conn = Database.getConnection();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT id, username, password, role FROM users WHERE username = ?")) {
+            ps.setString(1, username);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    User u = new User();
+                    u.setId(rs.getInt("id"));
+                    u.setUsername(rs.getString("username"));
+                    u.setPassword(rs.getString("password"));
+                    u.setRole(rs.getString("role"));
+                    return u;
+                }
             }
+        } catch (SQLException e) {
+            e.printStackTrace();
         }
         return null;
     }

--- a/test/com/alpacatours/dao/BookingDAOTest.java
+++ b/test/com/alpacatours/dao/BookingDAOTest.java
@@ -1,6 +1,7 @@
 package com.alpacatours.dao;
 
 import com.alpacatours.dao.BookingDAO;
+import com.alpacatours.dao.Database;
 import com.alpacatours.model.Booking;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -10,6 +11,7 @@ import java.sql.Date;
 public class BookingDAOTest {
     @Test
     public void testSaveAndFindAll() {
+        Database.reset();
         BookingDAO dao = new BookingDAO();
         Booking b = new Booking();
         b.setUserId(1);

--- a/test/com/alpacatours/dao/TourDAOTest.java
+++ b/test/com/alpacatours/dao/TourDAOTest.java
@@ -1,6 +1,7 @@
 package com.alpacatours.dao;
 
 import com.alpacatours.dao.TourDAO;
+import com.alpacatours.dao.Database;
 import com.alpacatours.model.Tour;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -8,6 +9,7 @@ import static org.junit.Assert.*;
 public class TourDAOTest {
     @Test
     public void testSaveAndFind() {
+        Database.reset();
         TourDAO dao = new TourDAO();
         Tour tour = new Tour();
         tour.setTitle("City Tour");

--- a/test/com/alpacatours/dao/UserDAOTest.java
+++ b/test/com/alpacatours/dao/UserDAOTest.java
@@ -1,6 +1,7 @@
 package com.alpacatours.dao;
 
 import com.alpacatours.dao.UserDAO;
+import com.alpacatours.dao.Database;
 import com.alpacatours.model.User;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -8,6 +9,7 @@ import static org.junit.Assert.*;
 public class UserDAOTest {
     @Test
     public void testSaveAndFindByUsername() {
+        Database.reset();
         UserDAO dao = new UserDAO();
         User user = new User();
         user.setUsername("alice");


### PR DESCRIPTION
## Summary
- add H2 dependency
- create `Database` helper to manage an in-memory H2 instance
- rework DAO classes to persist via JDBC instead of static lists
- reset database in DAO tests to ensure isolated runs

## Testing
- `mvn -q test` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840c3af3e508327962ad5a2c4b96761