### PR TITLE
Fix TLD loading by adding Struts taglib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
       <version>1.3.10</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.struts</groupId>
+      <artifactId>struts-taglib</artifactId>
+      <version>1.3.10</version>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <version>2.2.220</version>


### PR DESCRIPTION
## Summary
- include `struts-taglib` dependency so Struts TLDs are available at runtime

## Testing
- `mvn test` *(fails: Plugin resolution due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68418a816a848327a21e5d3da65f3115