### PR TITLE
Fix TLD lookup by using Struts taglib URI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
       <version>1.3.10</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.struts</groupId>
+      <artifactId>struts-taglib</artifactId>
+      <version>1.3.10</version>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <version>2.2.220</version>

--- a/web/booking.jsp
+++ b/web/booking.jsp
@@ -1,4 +1,4 @@
-<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 <html>
 <head><title>Book Tour</title></head>
 <body>

--- a/web/login.jsp
+++ b/web/login.jsp
@@ -1,4 +1,4 @@
-<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 <html>
 <head><title>Login</title></head>
 <body>

--- a/web/register.jsp
+++ b/web/register.jsp
@@ -1,4 +1,4 @@
-<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 <html>
 <head><title>Register</title></head>
 <body>

--- a/web/tours.jsp
+++ b/web/tours.jsp
@@ -1,4 +1,4 @@
-<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 <html>
 <head><title>Tours</title></head>
 <body>


### PR DESCRIPTION
## Summary
- use standard `struts-taglib` dependency
- reference Struts HTML taglib via URI instead of missing local TLD file

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418a816a848327a21e5d3da65f3115