### PR TITLE
Add user admin list

### DIFF
--- a/src/com/alpacatours/action/UserAction.java
+++ b/src/com/alpacatours/action/UserAction.java
@@ -32,6 +32,10 @@ public class UserAction extends Action {
             user.setRole("USER");
             userDAO.save(user);
             return mapping.findForward("success");
+        } else if ("/users".equals(action)) {
+            java.util.List<User> list = userDAO.findAll();
+            request.setAttribute("users", list);
+            return mapping.findForward("success");
         }
         return mapping.getInputForward();
     }

--- a/src/com/alpacatours/dao/UserDAO.java
+++ b/src/com/alpacatours/dao/UserDAO.java
@@ -47,4 +47,23 @@ public class UserDAO {
         }
         return null;
     }
+
+    public java.util.List<User> findAll() {
+        java.util.List<User> list = new java.util.ArrayList<>();
+        Connection conn = Database.getConnection();
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT id, username, password, role FROM users")) {
+            while (rs.next()) {
+                User u = new User();
+                u.setId(rs.getInt("id"));
+                u.setUsername(rs.getString("username"));
+                u.setPassword(rs.getString("password"));
+                u.setRole(rs.getString("role"));
+                list.add(u);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
 }

--- a/test/com/alpacatours/dao/UserDAOTest.java
+++ b/test/com/alpacatours/dao/UserDAOTest.java
@@ -20,4 +20,17 @@ public class UserDAOTest {
         assertEquals("alice", found.getUsername());
         assertEquals("secret", found.getPassword());
     }
+
+    @Test
+    public void testFindAll() {
+        Database.reset();
+        UserDAO dao = new UserDAO();
+        User a = new User();
+        a.setUsername("a");
+        dao.save(a);
+        User b = new User();
+        b.setUsername("b");
+        dao.save(b);
+        assertEquals(2, dao.findAll().size());
+    }
 }

--- a/web/WEB-INF/struts-config.xml
+++ b/web/WEB-INF/struts-config.xml
@@ -17,6 +17,9 @@
       <forward name="success" path="/login.jsp"/>
       <forward name="failure" path="/register.jsp"/>
     </action>
+    <action path="/users" type="com.alpacatours.action.UserAction" name="userForm" scope="request">
+      <forward name="success" path="/users.jsp"/>
+    </action>
     <action path="/tours" type="com.alpacatours.action.TourAction" name="tourForm" scope="request"/>
     <action path="/book" type="com.alpacatours.action.BookingAction" name="bookingForm" scope="request"/>
   </action-mappings>

--- a/web/index.jsp
+++ b/web/index.jsp
@@ -3,6 +3,7 @@
 <head><title>Alpaca Tours</title></head>
 <body>
   <h1>Welcome to Alpaca Tours</h1>
-  <a href="login.jsp">Login</a> | <a href="register.jsp">Register</a>
+  <a href="login.jsp">Login</a> | <a href="register.jsp">Register</a> |
+  <a href="users.do">User Admin</a>
 </body>
 </html>

--- a/web/users.jsp
+++ b/web/users.jsp
@@ -1,0 +1,21 @@
+<%@ page contentType="text/html;charset=UTF-8" %>
+<html>
+<head><title>User Administration</title></head>
+<body>
+  <h2>Users</h2>
+  <ul>
+<%
+    java.util.List<com.alpacatours.model.User> list =
+        (java.util.List<com.alpacatours.model.User>)request.getAttribute("users");
+    if (list != null) {
+        for (com.alpacatours.model.User u : list) {
+%>
+    <li><%= u.getUsername() %> (<%= u.getRole() %>)</li>
+<%
+        }
+    }
+%>
+  </ul>
+  <a href="register.jsp">Register New User</a> | <a href="index.jsp">Home</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend `UserDAO` with `findAll`
- handle `/users` path in `UserAction`
- add mapping for `/users` in `struts-config.xml`
- show user admin link from home page
- new `users.jsp` page for listing registered users
- expand DAO tests for `findAll`

## Testing
- `mvn -q test` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6841988b277c8327989ed8c46412be96