### PR TITLE
Add guide support and admin tour creation

### DIFF
--- a/src/com/alpacatours/action/TourAction.java
+++ b/src/com/alpacatours/action/TourAction.java
@@ -2,6 +2,7 @@ package com.alpacatours.action;
 
 import com.alpacatours.dao.TourDAO;
 import com.alpacatours.model.Tour;
+import com.alpacatours.form.TourForm;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.struts.action.Action;
@@ -16,6 +17,18 @@ public class TourAction extends Action {
     @Override
     public ActionForward execute(ActionMapping mapping, ActionForm form,
             HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String action = mapping.getPath();
+        if ("/addTour".equals(action)) {
+            TourForm tf = (TourForm) form;
+            Tour tour = new Tour();
+            tour.setTitle(tf.getTitle());
+            tour.setLocation(tf.getLocation());
+            tour.setPrice(tf.getPrice());
+            tour.setDescription(tf.getDescription());
+            tour.setCapacity(tf.getCapacity());
+            tour.setGuideId(tf.getGuideId());
+            tourDAO.save(tour);
+        }
         List<Tour> tours = tourDAO.findAll();
         request.setAttribute("tours", tours);
         return mapping.findForward("success");

--- a/src/com/alpacatours/action/UserAction.java
+++ b/src/com/alpacatours/action/UserAction.java
@@ -29,7 +29,11 @@ public class UserAction extends Action {
             User user = new User();
             user.setUsername(userForm.getUsername());
             user.setPassword(userForm.getPassword());
-            user.setRole("USER");
+            String role = userForm.getRole();
+            if (role == null || role.isEmpty()) {
+                role = "CUST";
+            }
+            user.setRole(role);
             userDAO.save(user);
             return mapping.findForward("success");
         } else if ("/users".equals(action)) {

--- a/src/com/alpacatours/dao/Database.java
+++ b/src/com/alpacatours/dao/Database.java
@@ -31,7 +31,8 @@ public class Database {
                 "location VARCHAR(255)," +
                 "price DOUBLE," +
                 "description VARCHAR(255)," +
-                "capacity INT)");
+                "capacity INT," +
+                "guideId INT)");
         stmt.execute("CREATE TABLE IF NOT EXISTS bookings(" +
                 "id INT AUTO_INCREMENT PRIMARY KEY," +
                 "userId INT," +

--- a/src/com/alpacatours/dao/TourDAO.java
+++ b/src/com/alpacatours/dao/TourDAO.java
@@ -13,13 +13,14 @@ public class TourDAO {
     public void save(Tour tour) {
         Connection conn = Database.getConnection();
         try (PreparedStatement ps = conn.prepareStatement(
-                "INSERT INTO tours(title, location, price, description, capacity) VALUES (?,?,?,?,?)",
+                "INSERT INTO tours(title, location, price, description, capacity, guideId) VALUES (?,?,?,?,?,?)",
                 Statement.RETURN_GENERATED_KEYS)) {
             ps.setString(1, tour.getTitle());
             ps.setString(2, tour.getLocation());
             ps.setDouble(3, tour.getPrice());
             ps.setString(4, tour.getDescription());
             ps.setInt(5, tour.getCapacity());
+            ps.setInt(6, tour.getGuideId());
             ps.executeUpdate();
             try (ResultSet rs = ps.getGeneratedKeys()) {
                 if (rs.next()) {
@@ -35,7 +36,7 @@ public class TourDAO {
         List<Tour> list = new ArrayList<>();
         Connection conn = Database.getConnection();
         try (Statement st = conn.createStatement();
-             ResultSet rs = st.executeQuery("SELECT id,title,location,price,description,capacity FROM tours")) {
+             ResultSet rs = st.executeQuery("SELECT id,title,location,price,description,capacity,guideId FROM tours")) {
             while (rs.next()) {
                 Tour t = new Tour();
                 t.setId(rs.getInt("id"));
@@ -44,6 +45,7 @@ public class TourDAO {
                 t.setPrice(rs.getDouble("price"));
                 t.setDescription(rs.getString("description"));
                 t.setCapacity(rs.getInt("capacity"));
+                t.setGuideId(rs.getInt("guideId"));
                 list.add(t);
             }
         } catch (SQLException e) {
@@ -55,7 +57,7 @@ public class TourDAO {
     public Tour findById(int id) {
         Connection conn = Database.getConnection();
         try (PreparedStatement ps = conn.prepareStatement(
-                "SELECT id,title,location,price,description,capacity FROM tours WHERE id=?")) {
+                "SELECT id,title,location,price,description,capacity,guideId FROM tours WHERE id=?")) {
             ps.setInt(1, id);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
@@ -66,6 +68,7 @@ public class TourDAO {
                     t.setPrice(rs.getDouble("price"));
                     t.setDescription(rs.getString("description"));
                     t.setCapacity(rs.getInt("capacity"));
+                    t.setGuideId(rs.getInt("guideId"));
                     return t;
                 }
             }

--- a/src/com/alpacatours/form/TourForm.java
+++ b/src/com/alpacatours/form/TourForm.java
@@ -8,6 +8,7 @@ public class TourForm extends ActionForm {
     private double price;
     private String description;
     private int capacity;
+    private int guideId;
 
     public String getTitle() { return title; }
     public void setTitle(String title) { this.title = title; }
@@ -23,4 +24,7 @@ public class TourForm extends ActionForm {
 
     public int getCapacity() { return capacity; }
     public void setCapacity(int capacity) { this.capacity = capacity; }
+
+    public int getGuideId() { return guideId; }
+    public void setGuideId(int guideId) { this.guideId = guideId; }
 }

--- a/src/com/alpacatours/form/UserForm.java
+++ b/src/com/alpacatours/form/UserForm.java
@@ -9,12 +9,16 @@ import org.apache.struts.validator.ValidatorForm;
 public class UserForm extends ValidatorForm {
     private String username;
     private String password;
+    private String role;
 
     public String getUsername() { return username; }
     public void setUsername(String username) { this.username = username; }
 
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
+
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
 
     @Override
     public ActionErrors validate(ActionMapping mapping, HttpServletRequest request) {

--- a/src/com/alpacatours/model/Tour.java
+++ b/src/com/alpacatours/model/Tour.java
@@ -7,6 +7,7 @@ public class Tour {
     private double price;
     private String description;
     private int capacity;
+    private int guideId;
 
     public int getId() { return id; }
     public void setId(int id) { this.id = id; }
@@ -25,4 +26,7 @@ public class Tour {
 
     public int getCapacity() { return capacity; }
     public void setCapacity(int capacity) { this.capacity = capacity; }
+
+    public int getGuideId() { return guideId; }
+    public void setGuideId(int guideId) { this.guideId = guideId; }
 }

--- a/test/com/alpacatours/dao/TourDAOTest.java
+++ b/test/com/alpacatours/dao/TourDAOTest.java
@@ -13,10 +13,12 @@ public class TourDAOTest {
         TourDAO dao = new TourDAO();
         Tour tour = new Tour();
         tour.setTitle("City Tour");
+        tour.setGuideId(1);
         dao.save(tour);
         assertEquals(1, dao.findAll().size());
         Tour found = dao.findById(tour.getId());
         assertNotNull(found);
         assertEquals("City Tour", found.getTitle());
+        assertEquals(1, found.getGuideId());
     }
 }

--- a/test/com/alpacatours/dao/UserDAOTest.java
+++ b/test/com/alpacatours/dao/UserDAOTest.java
@@ -14,6 +14,7 @@ public class UserDAOTest {
         User user = new User();
         user.setUsername("alice");
         user.setPassword("secret");
+        user.setRole("CUST");
         dao.save(user);
         User found = dao.findByUsername("alice");
         assertNotNull(found);
@@ -27,9 +28,11 @@ public class UserDAOTest {
         UserDAO dao = new UserDAO();
         User a = new User();
         a.setUsername("a");
+        a.setRole("CUST");
         dao.save(a);
         User b = new User();
         b.setUsername("b");
+        b.setRole("CUST");
         dao.save(b);
         assertEquals(2, dao.findAll().size());
     }

--- a/web/WEB-INF/struts-config.xml
+++ b/web/WEB-INF/struts-config.xml
@@ -20,7 +20,12 @@
     <action path="/users" type="com.alpacatours.action.UserAction" name="userForm" scope="request" validate="false">
       <forward name="success" path="/users.jsp"/>
     </action>
-    <action path="/tours" type="com.alpacatours.action.TourAction" name="tourForm" scope="request"/>
+    <action path="/tours" type="com.alpacatours.action.TourAction" name="tourForm" scope="request">
+      <forward name="success" path="/tours.jsp"/>
+    </action>
+    <action path="/addTour" type="com.alpacatours.action.TourAction" name="tourForm" scope="request">
+      <forward name="success" path="/tours.do" redirect="true"/>
+    </action>
     <action path="/book" type="com.alpacatours.action.BookingAction" name="bookingForm" scope="request"/>
   </action-mappings>
 </struts-config>

--- a/web/addTour.jsp
+++ b/web/addTour.jsp
@@ -1,0 +1,17 @@
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
+<html>
+<head><title>Add Tour</title></head>
+<body>
+  <h2>Add Tour</h2>
+  <html:form action="addTour.do">
+    Title: <html:text property="title" /><br/>
+    Location: <html:text property="location" /><br/>
+    Price: <html:text property="price" /><br/>
+    Description: <html:text property="description" /><br/>
+    Capacity: <html:text property="capacity" /><br/>
+    Guide ID: <html:text property="guideId" /><br/>
+    <html:submit value="Save" />
+  </html:form>
+  <a href="tours.do">Back to Tours</a>
+</body>
+</html>

--- a/web/index.jsp
+++ b/web/index.jsp
@@ -4,6 +4,6 @@
 <body>
   <h1>Welcome to Alpaca Tours</h1>
   <a href="login.jsp">Login</a> | <a href="register.jsp">Register</a> |
-  <a href="users.do">User Admin</a>
+  <a href="users.do">User Admin</a> | <a href="tours.do">Tours</a>
 </body>
 </html>

--- a/web/tours.jsp
+++ b/web/tours.jsp
@@ -3,7 +3,27 @@
 <head><title>Tours</title></head>
 <body>
   <h2>Tours</h2>
-  <!-- Placeholder for tour listing -->
+  <ul>
+  <%
+    java.util.List<com.alpacatours.model.Tour> list =
+      (java.util.List<com.alpacatours.model.Tour>)request.getAttribute("tours");
+    if (list != null) {
+        for (com.alpacatours.model.Tour t : list) {
+  %>
+    <li><%= t.getTitle() %> - guide <%= t.getGuideId() %></li>
+  <%
+        }
+    }
+  %>
+  </ul>
+  <%
+    com.alpacatours.model.User u = (com.alpacatours.model.User)session.getAttribute("user");
+    if (u != null && u.getRole() != null && u.getRole().contains("ADMIN")) {
+  %>
+    <a href="addTour.jsp">Add Tour</a><br/>
+  <%
+    }
+  %>
   <a href="index.jsp">Home</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link tours to a guide via `guideId`
- allow specifying role on registration, defaulting to CUST
- enable admin to add tours
- add JSP for tour creation and show tours list
- update DAO and tests for new field

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6841a4aa9944832790ab5d2a354ed725